### PR TITLE
fix: change transaction broadcast mode to sync

### DIFF
--- a/oracle/daemon/daemon.go
+++ b/oracle/daemon/daemon.go
@@ -55,7 +55,7 @@ func New(ctx context.Context) (*Daemon, error) {
 		WithClient(d.client).
 		WithFromAddress(config.Address()).
 		WithFromName(config.KeyName()).
-		WithBroadcastMode("block") // sync
+		WithBroadcastMode("sync") // TODO: if cosmos-sdk v0.50+, use "unordered"
 
 	d.monitor = monitor.New(d.clientCtx, d.ctx)
 	d.scheduler = scheduler.New()


### PR DESCRIPTION
In a future version, the broadcast mode block will be removed and changed to sync to alleviate the bottleneck.